### PR TITLE
Supported Python versions logo

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,10 +6,10 @@ PyTwin
    :target: https://docs.pyansys.com/
    :alt: PyAnsys
 
-.. |python| image:: https://img.shields.io/badge/Python-%3E%3D3.9-blue
+.. |python| image:: https://img.shields.io/pypi/pyversions/pytwin?logo=pypi
    :target: https://pypi.org/project/pytwin/
    :alt: Python
-
+   
 .. |pypi| image:: https://img.shields.io/pypi/v/pytwin.svg?logo=python&logoColor=white
    :target: https://pypi.org/project/pytwin/
    :alt: PyPI


### PR DESCRIPTION
Adding adequate badge for supported Python versions. This badge goes to PyPI to read the supported Python versions

![image](https://user-images.githubusercontent.com/37798125/211763129-e29eee30-9a93-47c0-aae2-3b9daf3b17e2.png)
