### PR TITLE
Fix issue with PyCharm debugging when pytest --cov is enabled

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ show_missing = true
 
 [tool.pytest.ini_options]
 minversion = "7.1"
-addopts = "-ra --cov=ansys.pytwin --cov-report html:.cov/html"
+addopts = "-ra"
 testpaths = [
     "tests",
 ]


### PR DESCRIPTION
Removing the --cov option from the [tool.pytest.ini_options] options since it appears to break PyCharm debugger.
See this thread: https://youtrack.jetbrains.com/issue/PY-20186