### PR TITLE
MAINT: Remove tests and doc dependencies from project.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,29 +29,6 @@ numpy = ">=1.14"
 pandas = ">=1.3.2"
 pywin32 = {version = ">=304", markers = "platform_system == 'Windows'"}
 
-[tool.poetry.group.test.dependencies]
-numpy = "1.23.4"
-pandas = "1.5.1"
-pytest = "7.1.2"
-pytest-cov = "^4.0.0"
-
-[tool.poetry.group.doc.dependencies]
-matplotlib = "^3.6.0"
-fluent = "^0.10.0"
-ansys-fluent-core = "^0.11.0"
-pyvista = "^0.36.1"
-ansys-mapdl-core = "^0.63.3"
-Sphinx = ">=4.4"
-Sphinx-copybutton = ">=0.4"
-numpydoc = ">=1.2"
-ansys_sphinx_theme = ">=0.2"
-sphinx_gallery = ">=0.11.1"
-jupyter_sphinx = ">=0.4.0"
-sphinx-notfound-page = ">=0.8.3"
-sphinx_autodoc_typehints = ">=1.19.5"
-sphinxemoji = ">=0.2.0"
-ansys-fluent-visualization = "^0.5.0"
-
 [tool.black]
 line-length = 120
 

--- a/src/ansys/pytwin/evaluate/saved_state_registry.py
+++ b/src/ansys/pytwin/evaluate/saved_state_registry.py
@@ -19,7 +19,7 @@ class SavedState:
     PARAMETERS_KEY = "parameters"
 
     def __init__(self):
-        self._id = f"{uuid.uuid4()}"[0:8]
+        self._id = f"{uuid.uuid4()}"[0:24].replace("-", "")
         self.time = None
         self.inputs = None
         self.outputs = None


### PR DESCRIPTION
+ Poetry fails to create a new python 3.9.10 env based on current project.toml due to conflicting dependencies found in tests (numpy + pandas) and doc groups (ansys-fluent-core + ansys-fluent-visualization). Since these dependencies are redundant with the folder requirements that is the one actually used in the github workflows to setup tests and doc actions, I suggest we remove this redundancy.
Impact for developers is these dependencies should now be manually added on top of the python env created with poetry, in order to run unit tests and doc build locally.
+ FIX Make SavedState id to be unique to fix occasionally failing unit test.